### PR TITLE
Upgrade mio, sha-1, log, env_logger and base64 to their respective latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ edition = "2018"
 mio = { version = "0.8", features = ["os-poll", "net"] }
 log = "0.4.16"
 env_logger = "0.9.0"
-base64 = "0.12.0"
+base64 = "0.13.0"
 sha-1 = "0.10.0"
 parsed = { version = "0.3.0", features = ["http"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["sergey-melnychuk"]
 edition = "2018"
 
 [dependencies]
-mio = "0.6"
+mio = { version = "0.8", features = ["os-poll", "net"] }
 log = "0.4.8"
 env_logger = "0.7.1"
 base64 = "0.12.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,5 @@ mio = { version = "0.8", features = ["os-poll", "net"] }
 log = "0.4.8"
 env_logger = "0.7.1"
 base64 = "0.12.0"
-sha-1 = "0.8.2"
+sha-1 = "0.10.0"
 parsed = { version = "0.3.0", features = ["http"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 
 [dependencies]
 mio = { version = "0.8", features = ["os-poll", "net"] }
-log = "0.4.8"
-env_logger = "0.7.1"
+log = "0.4.16"
+env_logger = "0.9.0"
 base64 = "0.12.0"
 sha-1 = "0.10.0"
 parsed = { version = "0.3.0", features = ["http"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,8 +32,8 @@ fn get_header<'a>(headers: &'a Vec<Header>, name: &str) -> Option<&'a str> {
 
 fn res_sec_websocket_accept(req_sec_websocket_key: &str) -> String {
     let mut hasher = Sha1::new();
-    hasher.input(req_sec_websocket_key.to_owned() + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
-    base64::encode(hasher.result())
+    hasher.update(req_sec_websocket_key.to_owned() + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11");
+    base64::encode(hasher.finalize())
 }
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/Writing_WebSocket_servers


### PR DESCRIPTION
This upgrades dependencies to their respective latest version.

[Mio 0.7 upgrade guide](https://tokio.rs/blog/2019-12-mio-v0.7-alpha.1) states that 
-  "In version 0.7 Mio registers all sources with edge triggers, removing the need for PollOpt."
-  "The Ready type, as used in registration, was changed to Interest to better reflect its usage."

Everything else was pretty straightforward. 
